### PR TITLE
chore: remove commented cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ ENTRYPOINT ["./startup.sh"]
 EXPOSE 3000
 
 # Configure the main process to run when running the image
-# CMD ["rails", "server", "-e", "production", "-b", "0.0.0.0"]
+CMD ["rails", "server", "-e", "production", "-b", "0.0.0.0"]


### PR DESCRIPTION
This pull request includes a minor change to the `Dockerfile`. The commented-out `CMD` line was uncommented to ensure the Rails server starts in production mode when the container runs.